### PR TITLE
72 checking contexts when creating a user context

### DIFF
--- a/backend/repetitor_backend/db/crud/customer_context.py
+++ b/backend/repetitor_backend/db/crud/customer_context.py
@@ -63,7 +63,8 @@ async def bidirectional_context_for_a_language_context_type(
         - context_2: UUID of context, used for ForeignKey links with Context
 
     Return:
-    - List that contains the results of the query, serialized to the CustomerContext type """
+    - List that contains the results of the query, serialized to the CustomerContext type
+    """
 
     query = tables.CustomerContext.objects()
     query = query.where(

--- a/backend/repetitor_backend/db/crud/customer_context.py
+++ b/backend/repetitor_backend/db/crud/customer_context.py
@@ -10,6 +10,8 @@ from repetitor_backend.api.v1.customer_context.serializers import (
     CustomerContextCreateRequest,
 )
 
+CONTEXT_CLASS_NAME_FOR_BIDIRECTIONAL = "language"
+
 
 async def create(**kwargs: CustomerContextCreateRequest | datetime) -> UUID | str:
     """Create new customer context.
@@ -24,7 +26,10 @@ async def create(**kwargs: CustomerContextCreateRequest | datetime) -> UUID | st
     """
 
     # kwargs["is_active"] = None
-    check_exists = await get(**kwargs)
+    check_exists = await get(
+        **kwargs
+    ) or await bidirectional_context_for_a_language_context_type(**kwargs)
+
     if check_exists:  # якщо існує  такий запис
         return (
             f"an object with such parameters already exists id={check_exists[0].id}  "
@@ -42,6 +47,25 @@ async def create(**kwargs: CustomerContextCreateRequest | datetime) -> UUID | st
     except ForeignKeyViolationError as e:
         return str(e)
     return result[0]["id"]
+
+
+async def bidirectional_context_for_a_language_context_type(
+    **get_param: GetCustomerContextRequest,
+) -> list[tables.CustomerContext] | None:
+    """ """
+    result = None
+    query = tables.CustomerContext.objects()
+    query = query.where(
+        (tables.CustomerContext.customer == get_param["customer"])
+        & (
+            tables.CustomerContext.context_1.context_class.name
+            == CONTEXT_CLASS_NAME_FOR_BIDIRECTIONAL
+        )
+        & (tables.CustomerContext.context_2 == get_param["context_1"])
+        & (tables.CustomerContext.context_1 == get_param["context_2"])
+    )
+    result = await query
+    return result
 
 
 async def get(**get_param: GetCustomerContextRequest) -> list[tables.CustomerContext]:

--- a/backend/repetitor_backend/db/crud/customer_context.py
+++ b/backend/repetitor_backend/db/crud/customer_context.py
@@ -52,8 +52,19 @@ async def create(**kwargs: CustomerContextCreateRequest | datetime) -> UUID | st
 async def bidirectional_context_for_a_language_context_type(
     **get_param: GetCustomerContextRequest,
 ) -> list[tables.CustomerContext] | None:
-    """ """
-    result = None
+    """checking contexts when creating a user context. bidirectionality check when the user context is created,
+    if the context type is context_1=="language". if true, prevents the creation of duplicates in the user context.
+    problem solving (customer, context_1, context_2) == (customer, context_2, context_1):
+
+        Parameters:
+        - id: UUID of customer context
+        - customer: UUID of customer, used for ForeignKey links with Customer
+        - context_1: UUID of context, used for ForeignKey links with Context
+        - context_2: UUID of context, used for ForeignKey links with Context
+
+    Return:
+    - List that contains the results of the query, serialized to the CustomerContext type """
+
     query = tables.CustomerContext.objects()
     query = query.where(
         (tables.CustomerContext.customer == get_param["customer"])

--- a/backend/repetitor_backend/db/crud/item_relation_view.py
+++ b/backend/repetitor_backend/db/crud/item_relation_view.py
@@ -126,8 +126,8 @@ async def get_words_from_the_db(
         - is_active: bool
     """
     # list_item_author.append(MICROSOFT_UUID)
-    queue = tables.ItemRelationView.select()
-    queue = queue.where(
+    query = tables.ItemRelationView.select()
+    query = query.where(
         (tables.ItemRelationView.is_active == is_active)
         & (
             (
@@ -172,7 +172,7 @@ async def get_words_from_the_db(
         tables.ItemRelationView.item_author_2,
         ascending=False,
     )
-    result = await queue
+    result = await query
     # міняю місцями щоб спочатку було source блок(i1, a1, c1), а потім target блок(i2, a2, c2)
     for i in result:
         if i["item_text_2"] == item_text:


### PR DESCRIPTION
вирішення проблеми (customer, context_1, context_2) == (customer, context_2, context_1)
Дописав перевірку двонаправленості при створені контексту користувача, якщо тип контексту у context_1=="language" context_1.context_class.name == CONTEXT_CLASS_NAME_FOR_BIDIRECTIONAL
Виніс у константу, якщо потрібно буде змінити .

Провів тестування.
якщо назва типу контекста == "language" , то повертає помилку
"an object with such parameters already exists id=fff72351-c022-42b1-bf85-f94cea0619d2 is_active=True "
і контекст користувача не створюється

якщо тип інший, то є можливість створювати два контексти з різними id